### PR TITLE
PR의 HEAD로 쏜 다른 PR 이 있을 때 머지하지 않기

### DIFF
--- a/bulldozer/evaluate.go
+++ b/bulldozer/evaluate.go
@@ -68,7 +68,7 @@ func setDifference(set1, set2 []string) []string {
 }
 
 // ShouldMergePR TODO: may want to return a richer type than bool
-func ShouldMergePR(ctx context.Context, pullCtx pull.Context, mergeConfig MergeConfig, client *github.Client) (bool, error) {
+func ShouldMergePR(ctx context.Context, pullCtx pull.Context, mergeConfig MergeConfig, openPRs []*github.PullRequest) (bool, error) {
 	logger := zerolog.Ctx(ctx)
 
 	if mergeConfig.Blacklist.Enabled() {
@@ -117,11 +117,6 @@ func ShouldMergePR(ctx context.Context, pullCtx pull.Context, mergeConfig MergeC
 	}
 
 	_, head := pullCtx.Branches()
-
-	openPRs, err := pull.ListOpenPullRequests(ctx, client, pullCtx.Owner(), pullCtx.Repo())
-	if err != nil {
-		return false, err
-	}
 	for _, openPR := range openPRs {
 		formattedRef := fmt.Sprintf("refs/heads/%s", openPR.GetBase().GetRef())
 		if formattedRef == head {

--- a/bulldozer/evaluate_test.go
+++ b/bulldozer/evaluate_test.go
@@ -101,13 +101,14 @@ func TestShouldMerge(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	openPRs := []*github.PullRequest{}
 
 	t.Run("fullCommentShouldMerge", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{
 			CommentValue: []string{"FULL_COMMENT_PLZ_MERGE"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.True(t, actualShouldMerge)
@@ -118,7 +119,7 @@ func TestShouldMerge(t *testing.T) {
 			CommentValue: []string{"This is not a FULL_COMMENT_PLZ_MERGE"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -129,7 +130,7 @@ func TestShouldMerge(t *testing.T) {
 			LabelValue: []string{"LABEL_MERGE"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.True(t, actualShouldMerge)
@@ -140,7 +141,7 @@ func TestShouldMerge(t *testing.T) {
 			LabelValue: []string{"LABEL_merGE"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.True(t, actualShouldMerge)
@@ -152,7 +153,7 @@ func TestShouldMerge(t *testing.T) {
 			CommentValue: []string{"commenta", "foo", "bar", "baz\n\rbaz"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -161,7 +162,7 @@ func TestShouldMerge(t *testing.T) {
 	t.Run("noMatchingShouldntMerge", func(t *testing.T) {
 		pc := &pulltest.MockPullContext{}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -173,7 +174,7 @@ func TestShouldMerge(t *testing.T) {
 			CommentValue: []string{"NO_WAY"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -184,7 +185,7 @@ func TestShouldMerge(t *testing.T) {
 			LabelValue: []string{"LABEL_NOMERGE"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -195,7 +196,7 @@ func TestShouldMerge(t *testing.T) {
 			LabelValue: []string{"LABEL_nomERGE"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -207,7 +208,7 @@ func TestShouldMerge(t *testing.T) {
 			CommentValue: []string{"a comment", "another comment", "this is good :+1: yep"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.True(t, actualShouldMerge)
@@ -219,7 +220,7 @@ func TestShouldMerge(t *testing.T) {
 			CommentValue: []string{"a comment", "another comment", "this is no good nope\n\r:-1:"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -232,7 +233,7 @@ func TestShouldMerge(t *testing.T) {
 			LabelErrValue: errors.New("failure"),
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.NotNil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -244,7 +245,7 @@ func TestShouldMerge(t *testing.T) {
 			CommentErrValue: errors.New("failure"),
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.NotNil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -256,7 +257,7 @@ func TestShouldMerge(t *testing.T) {
 			RequiredStatusesErrValue: errors.New("failure"),
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.NotNil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -268,7 +269,7 @@ func TestShouldMerge(t *testing.T) {
 			SuccessStatusesErrValue: errors.New("failure"),
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.NotNil(t, err)
 		assert.False(t, actualShouldMerge)
@@ -281,7 +282,7 @@ func TestShouldMerge(t *testing.T) {
 			RequiredStatusesValue: []string{"StatusCheckB", "StatusCheckA"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.True(t, actualShouldMerge)
@@ -294,7 +295,7 @@ func TestShouldMerge(t *testing.T) {
 			RequiredStatusesValue: []string{"StatusCheckA", "StatusCheckB"},
 		}
 
-		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig)
+		actualShouldMerge, err := ShouldMergePR(ctx, pc, mergeConfig, openPRs)
 
 		require.Nil(t, err)
 		assert.False(t, actualShouldMerge)

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -59,7 +59,7 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 		logger.Debug().Msgf("Found valid configuration for %s", bulldozerConfig)
 		config := *bulldozerConfig.Config
 
-		shouldMerge, err := bulldozer.ShouldMergePR(ctx, pullCtx, config.Merge)
+		shouldMerge, err := bulldozer.ShouldMergePR(ctx, pullCtx, config.Merge, client)
 		if err != nil {
 			return errors.Wrap(err, "unable to determine merge status")
 		}

--- a/server/handler/base.go
+++ b/server/handler/base.go
@@ -59,7 +59,8 @@ func (b *Base) ProcessPullRequest(ctx context.Context, pullCtx pull.Context, cli
 		logger.Debug().Msgf("Found valid configuration for %s", bulldozerConfig)
 		config := *bulldozerConfig.Config
 
-		shouldMerge, err := bulldozer.ShouldMergePR(ctx, pullCtx, config.Merge, client)
+		openPRs, _ := pull.ListOpenPullRequests(ctx, client, pullCtx.Owner(), pullCtx.Repo())
+		shouldMerge, err := bulldozer.ShouldMergePR(ctx, pullCtx, config.Merge, openPRs)
 		if err != nil {
 			return errors.Wrap(err, "unable to determine merge status")
 		}


### PR DESCRIPTION
## 구현
github client를 인자로 받으려 했으나, test 코드에서 이를 mocking하기 위해 만들어야하는 코드가 너무 많아져서 `[]*github.PullRequest` 를 인자로 받게 만들었습니다.